### PR TITLE
[FEAT] 로그인 기능 구현 #19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 	//인증코드 랜덤 생성
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
 	implementation 'me.paulschwarz:spring-dotenv:2.2.0'
+
+	//유효성 검사
+	implementation 'org.hibernate.validator:hibernate-validator'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/aica/aivoca/global/exception/auth/SecurityConfig.java
+++ b/src/main/java/com/aica/aivoca/global/exception/auth/SecurityConfig.java
@@ -1,12 +1,16 @@
 package com.aica.aivoca.global.exception.auth;
 
+import com.aica.aivoca.global.jwt.JwtTokenProvider;
+import com.aica.aivoca.global.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -15,18 +19,24 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtTokenProvider jwtTokenProvider;
+
     private static final String[] AUTH_WHITE_LIST = {
-            "/api/auth/**",
+            "/api/auth/**", // 회원가입, 토큰 재발급
+            "/swagger-ui/**", "/v3/api-docs/**", // Swagger
+            "/api/login", "/api/reissue",
     };
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
                     auth.anyRequest().authenticated();
-                });
+                })
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/aica/aivoca/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/aica/aivoca/global/exception/message/ErrorMessage.java
@@ -24,10 +24,20 @@ public enum ErrorMessage {
     // 서버 오류
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버에 알 수 없는 오류가 발생했습니다."),
 
+    //로그인 관련
+    USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자 아이디를 찾을 수 없습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED.value(),"유효하지 않은 비밀번호입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(),"유효하지 않은 리프레시토큰입니다."),
+    REFRESH_TOKEN_NOT_MATCH(HttpStatus.UNAUTHORIZED.value(),"리프레시토큰이 일차하지 않습니다."),
+
     // 단어 관련
     WORD_ID_REQUIRED(HttpStatus.BAD_REQUEST.value(), "단어 ID가 필요합니다."),
     WORD_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 단어를 찾을 수 없습니다."),
-    WORD_ALREADY_IN_VOCABULARY(HttpStatus.CONFLICT.value(), "이미 단어장에 존재하는 단어입니다.");
+    WORD_ALREADY_IN_VOCABULARY(HttpStatus.CONFLICT.value(), "이미 단어장에 존재하는 단어입니다."),
+
+
+
+    ;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/aica/aivoca/global/exception/message/SuccessMessage.java
+++ b/src/main/java/com/aica/aivoca/global/exception/message/SuccessMessage.java
@@ -19,7 +19,13 @@ public enum SuccessMessage {
     WORD_CACHED_SUCCESS(HttpStatus.CREATED.value(), "단어가 캐싱 테이블에 성공적으로 추가되었습니다."),
 
     // 단어장 추가
-    WORD_ADDED_TO_VOCABULARY(HttpStatus.OK.value(), "단어가 단어장에 성공적으로 추가되었습니다.");
+    WORD_ADDED_TO_VOCABULARY(HttpStatus.OK.value(), "단어가 단어장에 성공적으로 추가되었습니다."),
+
+    //로그인
+    LOGIN_SUCCESS(HttpStatus.OK.value(), "로그인에 성공하였습니다."),
+    TOKEN_REISSUE_SUCCESS(HttpStatus.CREATED.value(), "토큰이 재발행 되었습니다."),
+
+    ;
 
     private final int code;
     private final String message;

--- a/src/main/java/com/aica/aivoca/global/jwt/CustomUserDetails.java
+++ b/src/main/java/com/aica/aivoca/global/jwt/CustomUserDetails.java
@@ -1,0 +1,18 @@
+package com.aica.aivoca.global.jwt;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public record CustomUserDetails(Long userId, String userUid) implements UserDetails {
+
+    @Override public Collection<? extends GrantedAuthority> getAuthorities() { return List.of(); }
+    @Override public String getPassword() { return null; }
+    @Override public String getUsername() { return userUid; }
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/aica/aivoca/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/aica/aivoca/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.aica.aivoca.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 생성자 주입을 통해 JwtTokenProvider 주입
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // 요청에서 Authorization 헤더에 있는 토큰 추출
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Claims claims = jwtTokenProvider.getClaims(token);
+
+            Long userId = Long.parseLong(claims.getSubject());
+            String userUid = (String) claims.get("user_uid");
+
+            Authentication auth = new UsernamePasswordAuthenticationToken(
+                    new CustomUserDetails(userId, userUid),
+                    null,
+                    List.of()
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/aica/aivoca/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/aica/aivoca/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,91 @@
+package com.aica.aivoca.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * JWT 토큰을 생성하고, 유효성 검증 및 Claims 정보를 추출하는 유틸리티 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    // .env 에서 주입받는 값들
+    @Value("${JWT_SECRET_KEY}")
+    private String secretKey;
+
+    @Value("${JWT_ACCESS_EXPIRATION}")  // access 토큰 만료 시간 (ms)
+    private long accessTokenValidity;
+
+    @Value("${JWT_REFRESH_EXPIRATION}") // refresh 토큰 만료 시간 (ms)
+    private long refreshTokenValidity;
+
+    // 사용할 서명 알고리즘 (HMAC SHA-256)
+    private final SignatureAlgorithm SIGNATURE_ALGORITHM = SignatureAlgorithm.HS256;
+
+    /**
+     * AccessToken 생성 메서드
+     */
+    public String createAccessToken(Long userId, String userUid) {
+        return createToken(userId, userUid, accessTokenValidity);
+    }
+
+    /**
+     * RefreshToken 생성 메서드
+     */
+    public String createRefreshToken(Long userId, String userUid) {
+        return createToken(userId, userUid, refreshTokenValidity);
+    }
+
+
+    private String createToken(Long userId, String userUid, long validity) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(userId));
+        claims.put("user_uid", userUid);
+
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + validity);
+
+        // JWT 생성
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(
+                        Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)),
+                        SIGNATURE_ALGORITHM
+                )
+                .compact();
+    }
+
+    //토큰 유효성
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    //토큰 받기
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+}
+

--- a/src/main/java/com/aica/aivoca/login/controller/LoginController.java
+++ b/src/main/java/com/aica/aivoca/login/controller/LoginController.java
@@ -1,0 +1,35 @@
+package com.aica.aivoca.login.controller;
+
+import com.aica.aivoca.global.exception.dto.SuccessStatusResponse;
+import com.aica.aivoca.global.exception.message.SuccessMessage;
+import com.aica.aivoca.login.dto.LoginRequestDto;
+import com.aica.aivoca.login.dto.LoginResponseDto;
+import com.aica.aivoca.login.dto.TokenReissueRequestDto;
+import com.aica.aivoca.login.service.LoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class LoginController {
+
+    private final LoginService loginService;
+
+    @PostMapping("/login")
+    public ResponseEntity<SuccessStatusResponse<LoginResponseDto>> login(@RequestBody LoginRequestDto dto) {
+        LoginResponseDto tokenDto = loginService.login(dto);
+        return ResponseEntity.ok(SuccessStatusResponse.of(SuccessMessage.LOGIN_SUCCESS, tokenDto));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<SuccessStatusResponse<LoginResponseDto>> reissue(@RequestBody TokenReissueRequestDto dto) {
+        LoginResponseDto response = loginService.reissue(dto);
+        return ResponseEntity.ok(SuccessStatusResponse.of(SuccessMessage.TOKEN_REISSUE_SUCCESS, response));
+    }
+
+}

--- a/src/main/java/com/aica/aivoca/login/dto/LoginRequestDto.java
+++ b/src/main/java/com/aica/aivoca/login/dto/LoginRequestDto.java
@@ -1,0 +1,7 @@
+package com.aica.aivoca.login.dto;
+
+public record LoginRequestDto(
+        String userId,
+        String password,
+        boolean rememberMe
+) {}

--- a/src/main/java/com/aica/aivoca/login/dto/LoginResponseDto.java
+++ b/src/main/java/com/aica/aivoca/login/dto/LoginResponseDto.java
@@ -1,0 +1,6 @@
+package com.aica.aivoca.login.dto;
+
+public record LoginResponseDto(
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/com/aica/aivoca/login/dto/TokenReissueRequestDto.java
+++ b/src/main/java/com/aica/aivoca/login/dto/TokenReissueRequestDto.java
@@ -1,0 +1,3 @@
+package com.aica.aivoca.login.dto;
+
+public record TokenReissueRequestDto(String refreshToken) {}

--- a/src/main/java/com/aica/aivoca/login/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/aica/aivoca/login/repository/RefreshTokenRedisRepository.java
@@ -1,0 +1,31 @@
+package com.aica.aivoca.login.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRedisRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(Long userId, String refreshToken) {
+        String key = getKey(userId);
+        redisTemplate.opsForValue().set(key, refreshToken, 14, TimeUnit.DAYS); // TTL 설정
+    }
+
+    public String findByUserId(Long userId) {
+        return redisTemplate.opsForValue().get(getKey(userId));
+    }
+
+    public void delete(Long userId) {
+        redisTemplate.delete(getKey(userId));
+    }
+
+    private String getKey(Long userId) {
+        return "refresh:" + userId;
+    }
+}

--- a/src/main/java/com/aica/aivoca/login/service/LoginService.java
+++ b/src/main/java/com/aica/aivoca/login/service/LoginService.java
@@ -1,0 +1,91 @@
+package com.aica.aivoca.login.service;
+
+import com.aica.aivoca.domain.Users;
+import com.aica.aivoca.global.exception.BusinessException;
+import com.aica.aivoca.global.jwt.JwtTokenProvider;
+import com.aica.aivoca.login.dto.LoginRequestDto;
+import com.aica.aivoca.login.dto.LoginResponseDto;
+import com.aica.aivoca.login.dto.TokenReissueRequestDto;
+import com.aica.aivoca.login.repository.RefreshTokenRedisRepository;
+import com.aica.aivoca.user.repository.UsersRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import com.aica.aivoca.global.exception.message.ErrorMessage;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+    private final UsersRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    /**
+     * 사용자 로그인 처리 및 JWT 토큰 발급
+     * @param dto 로그인 요청 DTO (userId, password, rememberMe)
+     * @return accessToken, refreshToken 포함한 응답 DTO (rememberMe가 false면 refreshToken은 null)
+     */
+    public LoginResponseDto login(LoginRequestDto dto) {
+        // 사용자 조회 (user_uid 기준)
+        Users user = userRepository.findByUserId(dto.userId())
+                .orElseThrow(() -> new BusinessException(ErrorMessage.USER_ID_NOT_FOUND));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(dto.password(), user.getPassword())) {
+            throw new BusinessException(ErrorMessage.INVALID_PASSWORD);
+        }
+
+        // AccessToken 발급
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getUserId());
+
+        // RefreshToken 발급 및 저장 (rememberMe가 true일 경우에만)
+        String refreshToken = null;
+        if (dto.rememberMe()) {
+            refreshToken = jwtTokenProvider.createRefreshToken(user.getId(), user.getUserId());
+            refreshTokenRedisRepository.save(user.getId(), refreshToken);
+        }
+
+        return new LoginResponseDto(accessToken, refreshToken);
+    }
+
+
+    /**
+     * AccessToken 재발급 처리
+     * @param dto 클라이언트가 보낸 RefreshToken
+     * @return 새롭게 발급된 accessToken, refreshToken 응답 DTO
+     */
+    public LoginResponseDto reissue( TokenReissueRequestDto dto) {
+        String refreshToken = dto.refreshToken();
+
+        // RefreshToken 유효성 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new BusinessException(ErrorMessage.INVALID_REFRESH_TOKEN);
+        }
+
+        // RefreshToken 내부 정보 추출
+        Claims claims = jwtTokenProvider.getClaims(refreshToken);
+        Long userId = Long.parseLong(claims.getSubject());
+
+        // Redis에 저장된 RefreshToken과 일치하는지 확인
+        String savedRefreshToken = refreshTokenRedisRepository.findByUserId(userId);
+        if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
+            throw new BusinessException(ErrorMessage.REFRESH_TOKEN_NOT_MATCH);
+        }
+
+        // 사용자 재조회 (DB에서)
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorMessage.USER_ID_NOT_FOUND));
+
+        // 새로운 토큰 발급
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getUserId());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId(), user.getUserId());
+
+        // Redis에 RefreshToken 갱신
+        refreshTokenRedisRepository.save(user.getId(), newRefreshToken);
+
+        return new LoginResponseDto(newAccessToken, newRefreshToken);
+    }
+}


### PR DESCRIPTION
## 📌 Issue
- 로그인 기능 구현


## ✅ To Do List
- [x] 아이디/비밀번호 로그인 API 구현
- [x] 로그인 성공시 JWT 발급
- [x] 실패시 에러 응답 처리
- [x] 로그인 유지 선택 시 refresh token 발급

## 🤔 추가 논의할 점
- JWT 사용 시 보안 이슈

## 📆예상 기간
4/10 ~ 4/24

## 🔗 참고 자료
- #9 회원가입


close #19 