### PR TITLE
[ADD] JWT 필터 및 문장 추가 응답부분 코드 수정

### DIFF
--- a/src/main/java/com/aica/aivoca/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/aica/aivoca/global/jwt/JwtAuthenticationFilter.java
@@ -27,8 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/login",
             "/api/reissue",
             "/api/voca",
-            "/api/wordinfo",
-            "/api/sentence"
+            "/api/wordinfo"
     );
 
     @Override

--- a/src/main/java/com/aica/aivoca/sentence/dto/SentenceResponseDto.java
+++ b/src/main/java/com/aica/aivoca/sentence/dto/SentenceResponseDto.java
@@ -2,5 +2,5 @@ package com.aica.aivoca.sentence.dto;
 
 public record SentenceResponseDto(
         Long sentenceId,
-        Long userid,
+        Long userId,
         String sentence) {}


### PR DESCRIPTION
JWT 필터 잘못 설정해서 문장 관리 api 부분이 작동이 안되서 잘 작동되도록 수정하였고, 추가로 문장 추가 api 테스트 해보던 중 응답에서 유저 아이디가 userid로 i가 소문자로 나와 어색한 부분이 있어 userId로 수정